### PR TITLE
Add block email event observer

### DIFF
--- a/Controller/Process/BlockIwocaEmail.php
+++ b/Controller/Process/BlockIwocaEmail.php
@@ -1,0 +1,18 @@
+<?php
+namespace Iwoca\Iwocapay\Controller\Process;
+
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+
+class BlockIwocaEmail implements ObserverInterface
+{
+
+  public function execute(Observer $observer)
+  {
+    $order = $observer->getEvent()->getOrder();
+    $paymentMethod = $order->getPayment()->getMethod();
+    if ($paymentMethod == 'iwocapay') {
+      $order->setCanSendNewEmailFlag(false)->addCommentToStatusHistory(__('iwocaPay: Disabling send email'));
+    }
+  }
+}

--- a/etc/frontend/events.xml
+++ b/etc/frontend/events.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
+    <event name="sales_order_place_after">
+        <observer instance="Iwoca\Iwocapay\Controller\Process\BlockIwocaEmail" name="iwocapay_iwoca_email"/>
+    </event>
+</config>


### PR DESCRIPTION
Our customers are still getting emails, as soon as they hit checkout. One of our partners created workaround. I've just implementing that.