### PR TITLE
Increase pay later max to 30k

### DIFF
--- a/Model/Config/Source/PaymentTerms.php
+++ b/Model/Config/Source/PaymentTerms.php
@@ -12,7 +12,7 @@ class PaymentTerms implements OptionSourceInterface
     public const PAY_NOW_PAY_LATER = ['PAY_LATER', 'PAY_NOW'];
     public const PAY_LATER = ['PAY_LATER'];
     public const PAY_LATER_MIN_AMOUNT = 150;
-    public const PAY_LATER_MAX_AMOUNT = 15000;
+    public const PAY_LATER_MAX_AMOUNT = 30000;
 
     /**
      * @var Json


### PR DESCRIPTION
When we are in `pay_later` payment mode, we only show up as a method if we're within bounds (£150-£15,000)

This MR increases that max to £30,000.