### PR TITLE
Cron Job to prevent drop off and auto cancellation

### DIFF
--- a/Cron/ReconcileLostPayments.php
+++ b/Cron/ReconcileLostPayments.php
@@ -4,47 +4,33 @@ namespace Iwoca\Iwocapay\Cron;
 
 use Iwoca\Iwocapay\Model\Config;
 use Iwoca\Iwocapay\Model\IwocaClientFactory;
+use Iwoca\Iwocapay\Controller\Process\Callback;
+use Magento\Sales\Model\Order;
 use Magento\Sales\Model\OrderFactory;
 use Magento\Sales\Model\ResourceModel\Order\CollectionFactory;
-use Psr\Log\LoggerInterface;
 use Magento\Framework\Serialize\Serializer\Json;
-use GuzzleHttp\Exception\GuzzleException;
 use Magento\Framework\Exception\LocalizedException;
-use Magento\Sales\Model\Order;
+use Psr\Log\LoggerInterface;
+use GuzzleHttp\Exception\GuzzleException;
 
 class ReconcileLostPayments
 {
-    public const IWOCA_ORDER_ID_PARAM = 'orderId';
-
-    protected $orderFactory;
+    protected OrderFactory $orderFactory;
     protected IwocaClientFactory $iwocaClientFactory;
     private Config $config;
     private Json $jsonSerializer;
+    protected CollectionFactory $orderCollectionFactory;
+    protected LoggerInterface $logger;
 
-    /**
-     * @var CollectionFactory
-     */
-    protected $orderCollectionFactory;
-
-    /**
-     * @var LoggerInterface
-     */
-    protected $logger;
-
-    /**
-     * YourCustomJob constructor.
-     *
-     * @param CollectionFactory $orderCollectionFactory
-     * @param LoggerInterface $logger
-     */
     public function __construct(
-        CollectionFactory $orderCollectionFactory,
-        LoggerInterface $logger,
-        OrderFactory $orderFactory,
+        CollectionFactory  $orderCollectionFactory,
+        LoggerInterface    $logger,
+        OrderFactory       $orderFactory,
         IwocaClientFactory $iwocaClientFactory,
-        Config $config,
-        Json $jsonSerializer
-    ) {
+        Config             $config,
+        Json               $jsonSerializer
+    )
+    {
         $this->orderCollectionFactory = $orderCollectionFactory;
         $this->logger = $logger;
         $this->orderFactory = $orderFactory;
@@ -53,125 +39,87 @@ class ReconcileLostPayments
         $this->jsonSerializer = $jsonSerializer;
     }
 
-    /**
-     * Get all the payment pending orders which are iwocaPay.
-     */
     protected function getPendingIwocaPayOrders(): array
     {
-        $ordersCollection = $this->orderFactory->create()->getCollection();
         $orders = [];
-        foreach ($ordersCollection as $order) {
+        foreach ($this->orderFactory->create()->getCollection() as $order) {
             if ($order->getPayment()->getMethod() === 'iwocapay' && $order->getStatus() === 'pending_payment') {
                 $customerId = $order->getCustomerId();
-                if (!isset($orders[$customerId])) {
-                    $orders[$customerId] = [];
-                }
                 $orders[$customerId][] = $order;
             }
         }
         return $orders;
     }
 
-
-    /**
-     * OrderIds are not stored on the Order, but are contained within the order history.
-     * So we parse it out of the comment and return it sanitised here.
-     */
-    protected function findUUIDInOrderComments($order) {
-        $orderHistory = $order->getStatusHistoryCollection();
-        foreach ($orderHistory as $comment) {
-            $commentText = $comment->getComment();
-            preg_match('/"\b[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-4[A-Fa-f0-9]{3}-[89ABab][A-Fa-f0-9]{3}-[A-Fa-f0-9]{12}\b"/', $commentText, $matches);
-
-            if (!empty($matches)) {
+    protected function findUUIDInOrderComments($order)
+    {
+        foreach ($order->getStatusHistoryCollection() as $comment) {
+            if (preg_match('/"\b[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-4[A-Fa-f0-9]{3}-[89ABab][A-Fa-f0-9]{3}-[A-Fa-f0-9]{12}\b"/', $comment->getComment(), $matches)) {
                 return str_replace('"', '', $matches[0]);
             }
         }
-
         return null;
     }
 
-    /**
-     * Query the ecommerce api to check the status of the order to see if we need to mark
-     * it as complete/ rejected.
-     */
-    protected function getLatestStatusForIwocaPayOrder($order) {
+    protected function getLatestStatusForIwocaPayOrder($order): ?string
+    {
         $extractedOrderID = $this->findUUIDInOrderComments($order);
         if ($extractedOrderID === null) {
-            return $this->logger->error(
-               "iwp: Unable to retrieve order id for order."
-            );
+            $this->logger->error("ReconcileLostPayments: Unable to retrieve order id for order {$order->getIncrementId()}.");
+            return null;
         }
 
-        $iwocaClient = $this->iwocaClientFactory->create();
-
         try {
-            $rawResponse = $iwocaClient->get(
+            $rawResponse = $this->iwocaClientFactory->create()->get(
                 $this->config->getApiEndpoint(
                     Config::CONFIG_TYPE_GET_ORDER_ENDPOINT,
-                    [':' . self::IWOCA_ORDER_ID_PARAM => $extractedOrderID]
+                    [':' . Callback::IWOCA_ORDER_ID_PARAM => $extractedOrderID]
                 )
             );
-        } catch (GuzzleException $e) {
+        } catch (GuzzleException|LocalizedException $e) {
             $this->logger->info(
                 sprintf(
-                    'iwp: Error occurred while retrieving Iwoca order response for order with Iwoca ID %s. Received exception %s',
-                    $extractedOrderID,
+                    'ReconcileLostPayments: Error occurred while %s. Received exception %s',
+                    $e instanceof GuzzleException ? 'retrieving Iwoca order response for order with Iwoca ID ' . $extractedOrderID : 'getting API endpoint of type "' . Config::CONFIG_TYPE_GET_ORDER_ENDPOINT . '"',
                     $e->getMessage()
                 )
             );
-            throw $e;
-        } catch (LocalizedException $e) {
-            $this->logger->info(
-                sprintf(
-                    'iwp: Error occurred while getting API endpoint of type "%s". Exception: %s',
-                    Config::CONFIG_TYPE_GET_ORDER_ENDPOINT,
-                    $e->getMessage()
-                )
-            );
-            throw $e;
+            return null;
         }
 
         $responseJson = $rawResponse->getBody()->getContents();
         $responseData = $this->jsonSerializer->unserialize($responseJson);
-        return $responseData["data"]["status"];
+        return $responseData["data"]["status"] ?? null;
     }
 
+    private function markOrderAsProcessed($order)
+    {
+        $this->logger->info("ReconcileLostPayments: iwocaPay order with id {$order->getIncrementId()} has been completed and is being marked as processed.");
+        $order->setState(Order::STATE_PROCESSING)
+            ->setStatus(Order::STATE_PROCESSING)
+            ->addStatusToHistory(Order::STATE_PROCESSING, 'Order set to processing by the ReconcileLostPayments CRON job.', true)
+            ->save();
+    }
 
     /**
      * We only mark orders as successful here, we don't mark as cancelled if Declined as they may have checked out
-     * via a different method, and we want to avoid cancelling the order
+     * via a different method, and we want to avoid cancelling the order. They will be cancelled by the clean-up task
+     * anyway if they did not continue.
      */
     public function execute()
     {
-        $this->logger->info("iwp: ---");
-        $this->logger->info("iwp: ---");
-        $this->logger->info("iwp: Will reconcile any orders that have not already been marked as complete");
-
         try {
-            // Retrieve all pending orders
             $orders = $this->getPendingIwocaPayOrders();
             foreach ($orders as $customerId => $customerOrders) {
                 foreach ($customerOrders as $order) {
-                    $reference_id = $order->getIncrementId();
-                    $latestOrderId = $this->getLatestStatusForIwocaPayOrder($order);
-
-                    if ($latestOrderId === "SUCCESSFUL") {
-                        $this->logger->debug("iwp: Order with id {$reference_id} has been completed and we should mark as done...");
-
-                        $order->setState(Order::STATE_PROCESSING)
-                            ->setStatus(Order::STATE_PROCESSING)
-                            ->addStatusToHistory(Order::STATE_PROCESSING, 'Order set to processing by the ReconcileLostPayments CRON job.', true)
-                            ->save();
+                    $latestStatus = $this->getLatestStatusForIwocaPayOrder($order);
+                    if ($latestStatus === "SUCCESSFUL") {
+                        $this->markOrderAsProcessed($order);
                     }
                 }
             }
-
-
-            $this->logger->info('iwp: Finished looking at pending payments');
-            $this->logger->info('iwp: ---');
         } catch (\Exception $e) {
-            $this->logger->error('Error in YourCustomJob: ' . $e->getMessage());
+            $this->logger->error('ReconcileLostPayments: Error in ReconcileLostPayments CRON job' . $e->getMessage());
         }
     }
 }

--- a/Cron/ReconcileLostPayments.php
+++ b/Cron/ReconcileLostPayments.php
@@ -223,7 +223,6 @@ class ReconcileLostPayments
                             $this->markOrderAsProcessed($order);
                         }
                         if ($latestStatus === "PENDING") {
-                            $this->logger->error("ReconcileLostPayments: {$order->getUpdatedAt()}");
                             $this->prolongOrKillOrderLife($order);
                         }
                     } catch (\Exception $e) {

--- a/Cron/ReconcileLostPayments.php
+++ b/Cron/ReconcileLostPayments.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace Iwoca\Iwocapay\Cron;
+
+use Iwoca\Iwocapay\Model\Config;
+use Iwoca\Iwocapay\Model\IwocaClientFactory;
+use Magento\Sales\Model\OrderFactory;
+use Magento\Sales\Model\ResourceModel\Order\CollectionFactory;
+use Psr\Log\LoggerInterface;
+use Magento\Framework\Serialize\Serializer\Json;
+use GuzzleHttp\Exception\GuzzleException;
+use Magento\Framework\Exception\LocalizedException;
+
+class ReconcileLostPayments
+{
+    public const IWOCA_ORDER_ID_PARAM = 'orderId';
+    protected $orderFactory;
+    protected IwocaClientFactory $iwocaClientFactory;
+    private Config $config;
+    private Json $jsonSerializer;
+
+    /**
+     * @var CollectionFactory
+     */
+    protected $orderCollectionFactory;
+
+    /**
+     * @var LoggerInterface
+     */
+    protected $logger;
+
+    /**
+     * YourCustomJob constructor.
+     *
+     * @param CollectionFactory $orderCollectionFactory
+     * @param LoggerInterface $logger
+     */
+    public function __construct(
+        CollectionFactory $orderCollectionFactory,
+        LoggerInterface $logger,
+        OrderFactory $orderFactory,
+        IwocaClientFactory $iwocaClientFactory,
+        Config $config,
+        Json $jsonSerializer
+    ) {
+        $this->orderCollectionFactory = $orderCollectionFactory;
+        $this->logger = $logger;
+        $this->orderFactory = $orderFactory;
+        $this->iwocaClientFactory = $iwocaClientFactory;
+        $this->config = $config;
+        $this->jsonSerializer = $jsonSerializer;
+    }
+
+    /**
+     * Get all the payment pending orders which are iwocaPay.
+     */
+    protected function getPendingIwocaPayOrders(): array
+    {
+        $ordersCollection = $this->orderFactory->create()->getCollection();
+        $orders = [];
+        foreach ($ordersCollection as $order) {
+            if ($order->getPayment()->getMethod() === 'iwocapay' && $order->getStatus() === 'pending_payment') {
+                $customerId = $order->getCustomerId();
+                if (!isset($orders[$customerId])) {
+                    $orders[$customerId] = [];
+                }
+                $orders[$customerId][] = $order;
+            }
+        }
+        return $orders;
+    }
+
+
+    /**
+     * OrderIds are not stored on the Order, but are contained within the order history.
+     * So we parse it out of the comment and return it sanitised here.
+     */
+    protected function findUUIDInOrderComments($order) {
+        $orderHistory = $order->getStatusHistoryCollection();
+        foreach ($orderHistory as $comment) {
+            $commentText = $comment->getComment();
+            preg_match('/"\b[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-4[A-Fa-f0-9]{3}-[89ABab][A-Fa-f0-9]{3}-[A-Fa-f0-9]{12}\b"/', $commentText, $matches);
+
+            if (!empty($matches)) {
+                return str_replace('"', '', $matches[0]);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Query the ecommerce api to check the status of the order to see if we need to mark
+     * it as complete/ rejected.
+     */
+    protected function getLatestStatusForIwocaPayOrder($order) {
+        $extractedOrderID = $this->findUUIDInOrderComments($order);
+        if ($extractedOrderID === null) {
+            return $this->logger->error(
+               "iwp: Unable to retrieve order id for order."
+            );
+        }
+
+        $iwocaClient = $this->iwocaClientFactory->create();
+
+        try {
+            $rawResponse = $iwocaClient->get(
+                $this->config->getApiEndpoint(
+                    Config::CONFIG_TYPE_GET_ORDER_ENDPOINT,
+                    [':' . self::IWOCA_ORDER_ID_PARAM => $extractedOrderID]
+                )
+            );
+        } catch (GuzzleException $e) {
+            $this->logger->info(
+                sprintf(
+                    'iwp: Error occurred while retrieving Iwoca order response for order with Iwoca ID %s. Received exception %s',
+                    $extractedOrderID,
+                    $e->getMessage()
+                )
+            );
+            throw $e;
+        } catch (LocalizedException $e) {
+            $this->logger->info(
+                sprintf(
+                    'iwp: Error occurred while getting API endpoint of type "%s". Exception: %s',
+                    Config::CONFIG_TYPE_GET_ORDER_ENDPOINT,
+                    $e->getMessage()
+                )
+            );
+            throw $e;
+        }
+
+        $responseJson = $rawResponse->getBody()->getContents();
+        $responseData = $this->jsonSerializer->unserialize($responseJson);
+        return $responseData["data"]["status"];
+    }
+
+
+    public function execute()
+    {
+        $this->logger->info("iwp: ---");
+        $this->logger->info("iwp: ---");
+        $this->logger->info("iwp: Will reconcile any orders that have not already been marked as complete");
+
+        try {
+            // Retrieve all pending orders
+            $orders = $this->getPendingIwocaPayOrders();
+            foreach ($orders as $customerId => $customerOrders) {
+                foreach ($customerOrders as $order) {
+                    $reference_id = $order->getIncrementId();
+                    $latestOrderId = $this->getLatestStatusForIwocaPayOrder($order);
+                    if ($latestOrderId !== "COMPLETED") {
+                        $this->logger->debug("iwp: Order with id {$reference_id} has not been completed.");
+
+                    }else {
+                        $this->logger->debug("iwp: Order with id {$reference_id} has been completed and we should mark as done...");
+                        // ... MARK AS COMPLETED HERE
+                    }
+                }
+            }
+
+
+            $this->logger->info('iwp: Finished looking at pending payments');
+            $this->logger->info('iwp: ---');
+        } catch (\Exception $e) {
+            $this->logger->error('Error in YourCustomJob: ' . $e->getMessage());
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,12 @@
             "email": "martiniswink@gmail.com"
         },
         {
-          "name": "Sebastian Rother",
-          "email": "s.rother@iwoca.de"
+            "name": "Sebastian Rother",
+            "email": "s.rother@iwoca.de"
+        },
+        {
+            "name": "Joe McAlister",
+            "email": "j.mcalister@iwoca.co.uk"
         }
     ],
     "require": {

--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -8,3 +8,4 @@
         </job>
     </group>
 </config>
+

--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/crontab.xsd">
+    <group id="Iwoca_Iwocapay">
+        <job name="iwoca_pay_reconcile_lost_payments" instance="Iwoca\Iwocapay\Cron\ReconcileLostPayments" method="execute">
+            <schedule>* * * * *</schedule>
+        </job>
+    </group>
+</config>

--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/crontab.xsd">
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/crontab.xsd">
     <group id="Iwoca_Iwocapay">
-        <job name="iwoca_pay_reconcile_lost_payments" instance="Iwoca\Iwocapay\Cron\ReconcileLostPayments" method="execute">
-            <schedule>* * * * *</schedule>
+        <job name="iwoca_pay_reconcile_lost_payments" instance="Iwoca\Iwocapay\Cron\ReconcileLostPayments"
+             method="execute">
+            <schedule>30 * * * *</schedule>
         </job>
     </group>
 </config>


### PR DESCRIPTION
Currently there's two issues:

1. Payments in the "Pending payment" state are automatically cancelled after a user defined timeout (between 2 hours and 8 hours). This is within `Magento\Sales\Model\CronJob\CleanExpiredOrders`.
2. If a customer drops off before being redirected back they will never move from "Pending payment" to "Processing" meaning that order too will be cancelled after the time period mentioned above.

What this MR does:
- Creates a Cron Job that is ran every 30 minutes.
- This job checks each iwocaPay order in the "Pending payment" state against our API status
- If the order is successful it moves the order into the "Processing" state
- If the order is pending it will prolong the order timeout by altering updated_at field to be the current time. It will only do this for 48 hours, after this it is left for automatic clean up.

This approach is to be as minimally invasive as possible. As altering or editing the existing clean-up cron-job opens up a chance we could break this functionality if we don't maintain it. This approach is the least risky option due to the isolated nature.