### PR TITLE
basti / fix: prevent empty cart after iwocapay checkout

### DIFF
--- a/Controller/Process/CreateOrder.php
+++ b/Controller/Process/CreateOrder.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Iwoca\Iwocapay\Controller\Process;
@@ -182,7 +183,7 @@ class CreateOrder implements HttpGetActionInterface
                     RequestOptions::JSON => ['data' => $payload->toArray()]
                 ]
             );
-        } catch (GuzzleException|LocalizedException $e) {
+        } catch (GuzzleException | LocalizedException $e) {
             $this->addDebugLog(
                 sprintf(
                     'Error occurred while creating order in Iwoca for order with increment ID %s. Received exception: %s',

--- a/Helper/PageIdentifier.php
+++ b/Helper/PageIdentifier.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Iwoca\Iwocapay\Helper;
+
+use Magento\Framework\App\Helper\AbstractHelper;
+use Magento\Framework\App\Helper\Context;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\App\ResponseInterface;
+use Magento\Store\Model\StoreManagerInterface;
+
+enum PageType: string
+{
+    case CHECKOUT = 'checkout';
+    case BASKET = 'basket';
+    case EXTERNAL_REDIRECT = 'external_redirect';
+    case INTERNAL_REDIRECT = 'internal_redirect';
+    case NOT_A_PAGE = 'not_a_page';
+    case UNKNOWN = 'unknown';
+}
+
+class PageIdentifier extends AbstractHelper
+{
+    /**
+     * @var RequestInterface
+     */
+    protected $request;
+
+    /**
+     * @var ResponseInterface
+     */
+    protected $response;
+
+    /**
+     * @var StoreManagerInterface
+     */
+    protected $storeManager;
+
+    /**
+     * Constructor
+     *
+     * @param Context $context
+     * @param RequestInterface $request
+     */
+    public function __construct(Context $context, RequestInterface $request, ResponseInterface $response, StoreManagerInterface $storeManager)
+    {
+        parent::__construct($context);
+        $this->request = $request;
+        $this->response = $response;
+        $this->storeManager = $storeManager;
+    }
+
+    public function isLandingPage(): bool
+    {
+        return !$this->request->getServer('HTTP_REFERER');
+    }
+
+    public function getType(): PageType
+    {
+        $isAjax = $this->request->isXmlHttpRequest();
+        $isGet = $this->request->isGet();
+
+        if ($isAjax || !$isGet) {
+            return PageType::NOT_A_PAGE;
+        }
+
+        $redirectUrl = strval($this->response->getHeader('Location'));
+        $baseUrl = $this->storeManager->getStore()->getBaseUrl();
+
+        if ($redirectUrl) {
+            if (strpos($redirectUrl, $baseUrl) === false) {
+                return PageType::EXTERNAL_REDIRECT;
+            }
+            return PageType::INTERNAL_REDIRECT;
+        }
+
+        if ($this->isCheckoutPage()) {
+            return PageType::CHECKOUT;
+        }
+
+        if ($this->isBasketPage()) {
+            return PageType::BASKET;
+        }
+
+        return PageType::UNKNOWN;
+    }
+
+    /**
+     * Check if the current page is a checkout page
+     *
+     * @return bool
+     */
+    public function isCheckoutPage(): bool
+    {
+        $routeName = $this->request->getRouteName();
+        $controllerName = $this->request->getControllerName();
+        $actionName = $this->request->getActionName();
+
+        // Check for common checkout pages
+        if ($routeName === 'checkout') {
+            return true;
+        }
+
+        // Additional checks for specific checkout steps
+        if ($routeName === 'onestepcheckout' || $routeName === 'multistepcheckout') {
+            return true;
+        }
+
+        if ($routeName === 'firecheckout' || $routeName === 'amasty_checkout') {
+            return true;
+        }
+
+        // Add more custom checks if needed
+        return false;
+    }
+
+    /**
+     * Check if the current page is a basket (cart) page
+     *
+     * @return bool
+     */
+    public function isBasketPage(): bool
+    {
+        $routeName = $this->request->getRouteName();
+        $controllerName = $this->request->getControllerName();
+        $actionName = $this->request->getActionName();
+
+        // Check for common basket (cart) pages
+        if ($routeName === 'checkout' && $controllerName === 'cart') {
+            return true;
+        }
+
+        // Additional checks for specific cart actions
+        if ($routeName === 'checkout' && in_array($controllerName, ['cart', 'minicart'])) {
+            return true;
+        }
+
+        if ($routeName === 'sales' && $controllerName === 'quote') {
+            return true;
+        }
+
+        // Add more custom checks if needed
+        return false;
+    }
+}

--- a/Observer/CustomerReturnObserver.php
+++ b/Observer/CustomerReturnObserver.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Iwoca\Iwocapay\Observer;
+
+use Iwoca\Iwocapay\Helper\PageIdentifier;
+use Iwoca\Iwocapay\Helper\PageType;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Framework\Event\Observer;
+use Psr\Log\LoggerInterface;
+use Magento\Quote\Model\QuoteRepository;
+use Magento\Checkout\Model\Session as CheckoutSession;
+use Magento\Sales\Model\OrderFactory;
+use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Framework\App\RequestInterface;
+
+/*
+This observer handles the restoration on iwocaPay shopping carts.
+If a customer checks out with iwocaPay and returns via the back button
+the order is canceled and the quote is restored.
+
+It checks the following conditions:
+- If the request is not for a page, don't do anything
+- If the request is for any page other than the checkout or cart don't do anything
+- If the request is for any page other than the checkout or cart and the referrer is not the store:
+    This is a proxy for a customer reentering the store not using the back button
+    Set the allow_cancel_order flag to false
+    (This prevents the order from being canceled when the customer returns to the store via URL navigation
+- If the request is for the checkout or cart page:
+    - check if the allow_cancel_order flag is set to true.
+       (this only happens if the customer is returning to the store via the back button)
+    - check if the current quote is empty (this avoids overriding the quote with the previous one)
+    - check if the last order was paid with iwocaPay
+    - cancel the previous order
+    - make sure enough stoke is available
+    - restore the quote
+- If the request is a redirect to iwocaPay:
+    Set the allow_cancel_order flag to true
+    (this allows the order to be canceled when the customer returns to the store via the back button)
+
+                Redirect                                           
+              - Referrer === Checkout location                   
+              - Redirect to outside store                        
++-----------+ => set allow_cancel_order flag to true +----------+
+| Checkout  +--------------------------------------> | iwocaPay |
++-----------+                                        +----+-+---+
+     ^ ^                                                  | |    
+     | |                                                  | |    
+     | +--------------------------------------------------+ |    
+     |            Back Button                               |    
+     |            - Location === Checkout || Cart           |    
+     |            - allow_cancel_order === true             |    
+     |            => Cancel latest iwocaPay order           |    
+     |            => Recreate latest iwocaPay quote         |    
+     |                                                      |    
+  +--+----+                                                 |    
+  | Store | <-----------------------------------------------+    
+  +-------+    Navigation                                        
+               - No referrer                                     
+               - Location !== Checkout || Cart                   
+               => set allow_cancel_order_flag to false           
+ */
+
+class CustomerReturnObserver implements ObserverInterface
+{
+    /**
+     * @var LoggerInterface
+     */
+    protected $logger;
+
+    /**
+     * @var QuoteRepository
+     */
+    protected $quoteRepository;
+
+    /**
+     * @var CheckoutSession
+     */
+    protected $checkoutSession;
+
+    /**
+     * @var OrderFactory
+     */
+    protected $orderFactory;
+
+    /**
+     * @var PageIdentifier
+     */
+    protected $pageIdentifier;
+
+    /**
+     * @var CartRepositoryInterface
+     */
+    protected $cartRepository;
+
+    /**
+     * @var RequestInterface
+     */
+    protected $request;
+
+    /**
+     * Constructor
+     *
+     * @param LoggerInterface $logger
+     * @param QuoteRepository $quoteRepository
+     * @param CheckoutSession $checkoutSession
+     * @param OrderFactory $orderFactory
+     * @param PageIdentifier $pageIdentifier
+     * @param CartRepositoryInterface $cartRepository
+     * @param RequestInterface $request
+     */
+    public function __construct(
+        LoggerInterface $logger,
+        QuoteRepository $quoteRepository,
+        CheckoutSession $checkoutSession,
+        OrderFactory $orderFactory,
+        PageIdentifier $pageIdentifier,
+        CartRepositoryInterface $cartRepository,
+        RequestInterface $request,
+    ) {
+        $this->logger = $logger;
+        $this->quoteRepository = $quoteRepository;
+        $this->checkoutSession = $checkoutSession;
+        $this->orderFactory = $orderFactory;
+        $this->pageIdentifier = $pageIdentifier;
+        $this->cartRepository = $cartRepository;
+        $this->request = $request;
+    }
+
+
+    /**
+     * Cancel previous order and reactivate the quote when returning to the checkout cart
+     *
+     * @param Observer $observer
+     * @return void
+     */
+    public function execute(Observer $observer)
+    {
+        $pageType = $this->pageIdentifier->getType();
+        $isLandingPage = $this->pageIdentifier->isLandingPage();
+
+        if ($pageType === PageType::NOT_A_PAGE) {
+            return;
+        }
+
+        if ($pageType === PageType::UNKNOWN && $isLandingPage) {
+            $this->checkoutSession->setData('allow_cancel_order', false);
+        }
+
+        if ($pageType === PageType::EXTERNAL_REDIRECT) {
+            $this->checkoutSession->setData('allow_cancel_order', true);
+            return;
+        }
+
+        if (!$this->checkoutSession->getData('allow_cancel_order')) {
+            return;
+        }
+
+        $currentQuote = $this->checkoutSession->getQuote();
+
+        if ($currentQuote->getItemsCount() > 0) return;
+
+        $orderId = $this->checkoutSession->getLastOrderId();
+
+        if (!$orderId) return;
+
+        $order = $this->orderFactory->create()->load($orderId);
+        $payment = $order->getPayment();
+
+        if (!$payment || $payment->getMethod() !== 'iwocapay') return;
+
+        if ($order->getStatus() !== \Magento\Sales\Model\Order::STATE_PENDING_PAYMENT) return;
+
+        if (!$order->canCancel()) return;
+
+        try {
+            $order->cancel();
+            $order->addStatusHistoryComment('Order canceled as user returned to checkout cart without completing iwocapay.');
+            $order->save();
+        } catch (\Exception $e) {
+            $this->logger->error('Error canceling order: ' . $e->getMessage());
+        }
+
+        $quoteId = $order->getQuoteId();
+
+        if (!$quoteId) return;
+
+        try {
+            $quote = $this->quoteRepository->get($quoteId);
+        } catch (\Exception $e) {
+            $this->logger->error('Error loading quote: ' . $e->getMessage());
+            return;
+        }
+
+        if (!$quote) return;
+
+        foreach ($quote->getAllItems() as $item) {
+            $item->setIsActive(true);
+            $item->setQty($item->getQty());
+        }
+
+        $quote->setIsActive(true)->save();
+
+        try {
+            $this->quoteRepository->save($quote); // Save the quote to ensure changes are persisted
+        } catch (\Exception $e) {
+            $this->logger->error('Error saving quote: ' . $e->getMessage());
+            return;
+        }
+
+        $this->checkoutSession->replaceQuote($quote);
+    }
+}

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -3,4 +3,7 @@
     <event name="sales_model_service_quote_submit_before">
         <observer name="iwoca_disable_place_order_email" instance="Iwoca\Iwocapay\Observer\DisableOrderEmailBeforeQuoteSubmit" shared="false" />
     </event>
+    <event name="controller_front_send_response_before">
+        <observer name="iwoca_iwocapay_cancel_order_and_reactivate_quote" instance="Iwoca\Iwocapay\Observer\CustomerReturnObserver" />
+    </event>
 </config>

--- a/view/frontend/layout/default_head_blocks.xml
+++ b/view/frontend/layout/default_head_blocks.xml
@@ -1,0 +1,5 @@
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <head>
+        <script src="Iwoca_Iwocapay::js/reload-mini-cart.js"/>
+    </head>
+</page>

--- a/view/frontend/web/js/reload-mini-cart.js
+++ b/view/frontend/web/js/reload-mini-cart.js
@@ -1,0 +1,16 @@
+require(["jquery", "Magento_Customer/js/customer-data"], function (
+  $,
+  customerData
+) {
+  "use strict";
+
+  $(document).ready(function () {
+    const isCartPage = window.location.href.includes("checkout/cart");
+    const cartElementExists = $(".cart-container").length > 0;
+    const isCart = isCartPage || cartElementExists;
+
+    if (!isCart) return;
+
+    customerData.reload(["cart"], true);
+  });
+});


### PR DESCRIPTION
This fixes an edgecase where the iwocaPay plugin emptys the cart after checkout.
If the customer returns via usage of the "back" button, the quote will be restored.