### PR TITLE
Split Magento payment options into two 

### DIFF
--- a/Controller/Process/BlockIwocaEmail.php
+++ b/Controller/Process/BlockIwocaEmail.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Iwoca\Iwocapay\Controller\Process;
 
 use Magento\Framework\Event\Observer;
@@ -6,13 +7,12 @@ use Magento\Framework\Event\ObserverInterface;
 
 class BlockIwocaEmail implements ObserverInterface
 {
-
-  public function execute(Observer $observer)
-  {
-    $order = $observer->getEvent()->getOrder();
-    $paymentMethod = $order->getPayment()->getMethod();
-    if ($paymentMethod == 'iwocapay' || $paymentMethod == 'iwocapay_paylater' || $paymentMethod == 'iwocapay_paynow' ) {
-      $order->setCanSendNewEmailFlag(false)->addCommentToStatusHistory(__('iwocaPay: Disabling send email'));
+    public function execute(Observer $observer)
+    {
+        $order = $observer->getEvent()->getOrder();
+        $paymentMethod = $order->getPayment()->getMethod();
+        if ($paymentMethod == 'iwocapay' || $paymentMethod == 'iwocapay_paylater' || $paymentMethod == 'iwocapay_paynow') {
+            $order->setCanSendNewEmailFlag(false)->addCommentToStatusHistory(__('iwocaPay: Disabling send email'));
+        }
     }
-  }
 }

--- a/Controller/Process/BlockIwocaEmail.php
+++ b/Controller/Process/BlockIwocaEmail.php
@@ -11,7 +11,7 @@ class BlockIwocaEmail implements ObserverInterface
   {
     $order = $observer->getEvent()->getOrder();
     $paymentMethod = $order->getPayment()->getMethod();
-    if ($paymentMethod == 'iwocapay') {
+    if ($paymentMethod == 'iwocapay' || $paymentMethod == 'iwocapay_paylater' || $paymentMethod == 'iwocapay_paynow' ) {
       $order->setCanSendNewEmailFlag(false)->addCommentToStatusHistory(__('iwocaPay: Disabling send email'));
     }
   }

--- a/Controller/Process/CreateOrder.php
+++ b/Controller/Process/CreateOrder.php
@@ -135,7 +135,7 @@ class CreateOrder implements HttpGetActionInterface
 
         $createOrder->setAmount((float)$order->getGrandTotal())
             ->setReference($order->getIncrementId())
-            ->setAllowedPaymentTerms($this->config->getAllowedPaymentTerms())
+            ->setAllowedPaymentTerms($this->config->getAllowedPaymentTermOptions($order->getPayment()->getMethod()))
             ->setSource($this->config->getSource())
             ->setRedirectUrl($this->getRedirectUrl());
 

--- a/Controller/Process/CreateOrder.php
+++ b/Controller/Process/CreateOrder.php
@@ -58,19 +58,20 @@ class CreateOrder implements HttpGetActionInterface
      * @param LoggerInterface $logger
      */
     public function __construct(
-        ResultFactory $resultFactory,
+        ResultFactory                      $resultFactory,
         CreateOrderPayloadInterfaceFactory $createOrderPayloadFactory,
-        IwocaClientFactory $iwocaClientFactory,
-        Config $config,
-        CreateOrderInterfaceFactory $createOrderInterfaceFactory,
-        Json $jsonSerializer,
-        OrderRepositoryInterface $orderRepository,
-        Session $checkoutSession,
-        ManagerInterface $messageManager,
-        CartRepositoryInterface $quoteRepository,
-        StoreManagerInterface $storeManager,
-        LoggerInterface $logger
-    ) {
+        IwocaClientFactory                 $iwocaClientFactory,
+        Config                             $config,
+        CreateOrderInterfaceFactory        $createOrderInterfaceFactory,
+        Json                               $jsonSerializer,
+        OrderRepositoryInterface           $orderRepository,
+        Session                            $checkoutSession,
+        ManagerInterface                   $messageManager,
+        CartRepositoryInterface            $quoteRepository,
+        StoreManagerInterface              $storeManager,
+        LoggerInterface                    $logger
+    )
+    {
         $this->resultFactory = $resultFactory;
         $this->createOrderPayloadFactory = $createOrderPayloadFactory;
         $this->iwocaClientFactory = $iwocaClientFactory;
@@ -183,7 +184,7 @@ class CreateOrder implements HttpGetActionInterface
                     RequestOptions::JSON => ['data' => $payload->toArray()]
                 ]
             );
-        } catch (GuzzleException | LocalizedException $e) {
+        } catch (GuzzleException|LocalizedException $e) {
             $this->addDebugLog(
                 sprintf(
                     'Error occurred while creating order in Iwoca for order with increment ID %s. Received exception: %s',

--- a/Cron/CancelAbandonedOrders.php
+++ b/Cron/CancelAbandonedOrders.php
@@ -57,7 +57,7 @@ class CancelAbandonedOrders
                 'main_table.entity_id = payment.parent_id',
                 ['method']
             )
-            ->addFieldToFilter('payment.method', 'iwocapay')
+            ->addFieldToFilter('payment.method', ['in' => ['iwocapay', 'iwocapay_paylater', 'iwocapay_paynow']])
             ->addFieldToFilter('main_table.status', Order::STATE_CANCELED);
     }
 

--- a/Cron/CancelAbandonedOrders.php
+++ b/Cron/CancelAbandonedOrders.php
@@ -101,7 +101,7 @@ class CancelAbandonedOrders
                     [':' . Callback::IWOCA_ORDER_ID_PARAM => $extractedOrderID]
                 )
             );
-        } catch (GuzzleException | LocalizedException $e) {
+        } catch (GuzzleException|LocalizedException $e) {
             throw new LocalizedException(__('An error occurred: %1', $e->getMessage()));
         } catch (\Exception $e) {
             throw new LocalizedException(__('An error occurred: %1', $e->getMessage()));

--- a/Cron/ReconcileLostPayments.php
+++ b/Cron/ReconcileLostPayments.php
@@ -75,7 +75,7 @@ class ReconcileLostPayments
         Json               $jsonSerializer,
         TimezoneInterface  $timezone,
         ResourceConnection $resourceConnection,
-        OrderSender $orderSender
+        OrderSender        $orderSender
     )
     {
         $this->orderCollectionFactory = $orderCollectionFactory;

--- a/Cron/ReconcileLostPayments.php
+++ b/Cron/ReconcileLostPayments.php
@@ -102,7 +102,7 @@ class ReconcileLostPayments
                 'main_table.entity_id = payment.parent_id',
                 ['method']
             )
-            ->addFieldToFilter('payment.method', 'iwocapay')
+            ->addFieldToFilter('payment.method', ['in' => ['iwocapay', 'iwocapay_paylater', 'iwocapay_paynow']])
             ->addFieldToFilter('main_table.status', 'pending_payment');
     }
 

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -60,8 +60,9 @@ class Config
      */
     public function __construct(
         ScopeConfigInterface $scopeConfig,
-        Json $jsonSerializer
-    ){
+        Json                 $jsonSerializer
+    )
+    {
         $this->scopeConfig = $scopeConfig;
         $this->jsonSerializer = $jsonSerializer;
     }
@@ -85,7 +86,7 @@ class Config
         if (!$this->getSellerId() || !$this->getSellerAccessToken()) {
             return false;
         }
-         return true;
+        return true;
     }
 
     /**
@@ -93,7 +94,7 @@ class Config
      */
     public function getSellerAccessToken(): string
     {
-        return (string) $this->scopeConfig->getValue(self::XML_CONFIG_PATH_SELLER_ACCESS_TOKEN, ScopeInterface::SCOPE_WEBSITE);
+        return (string)$this->scopeConfig->getValue(self::XML_CONFIG_PATH_SELLER_ACCESS_TOKEN, ScopeInterface::SCOPE_WEBSITE);
     }
 
     /**
@@ -101,7 +102,7 @@ class Config
      */
     public function getSellerId(): string
     {
-        return (string) $this->scopeConfig->getValue(self::XML_CONFIG_PATH_SELLER_ID, ScopeInterface::SCOPE_WEBSITE);
+        return (string)$this->scopeConfig->getValue(self::XML_CONFIG_PATH_SELLER_ID, ScopeInterface::SCOPE_WEBSITE);
     }
 
 
@@ -110,7 +111,7 @@ class Config
      */
     public function getMode(): int
     {
-        return (int) $this->scopeConfig->getValue(self::XML_CONFIG_PATH_MODE, ScopeInterface::SCOPE_WEBSITE);
+        return (int)$this->scopeConfig->getValue(self::XML_CONFIG_PATH_MODE, ScopeInterface::SCOPE_WEBSITE);
     }
 
     /**
@@ -152,7 +153,7 @@ class Config
     public function getTitle(string $methodCode): string
     {
         $path = sprintf(self::XML_CONFIG_PATH_TITLE, $methodCode);
-        return (string) $this->scopeConfig->getValue($path, ScopeInterface::SCOPE_STORE);
+        return (string)$this->scopeConfig->getValue($path, ScopeInterface::SCOPE_STORE);
     }
 
     /**
@@ -162,7 +163,7 @@ class Config
     public function getSubtitle(string $methodCode): string
     {
         $path = sprintf(self::XML_CONFIG_PATH_SUBTITLE, $methodCode);
-        return (string) $this->scopeConfig->getValue($path, ScopeInterface::SCOPE_STORE);
+        return (string)$this->scopeConfig->getValue($path, ScopeInterface::SCOPE_STORE);
     }
 
     /**
@@ -172,7 +173,7 @@ class Config
     public function getCallToAction(string $methodCode): string
     {
         $path = sprintf(self::XML_CONFIG_PATH_CALL_TO_ACTION, $methodCode);
-        return (string) $this->scopeConfig->getValue($path, ScopeInterface::SCOPE_STORE);
+        return (string)$this->scopeConfig->getValue($path, ScopeInterface::SCOPE_STORE);
     }
 
     /**
@@ -188,7 +189,7 @@ class Config
      */
     public function getSource(): string
     {
-        return (string) $this->scopeConfig->getValue(self::XML_PATH_SOURCE);
+        return (string)$this->scopeConfig->getValue(self::XML_PATH_SOURCE);
     }
 
     /**
@@ -196,7 +197,7 @@ class Config
      */
     public function getRedirectPath(): string
     {
-        return (string) $this->scopeConfig->getValue(self::XML_PATH_REDIRECT_PATH);
+        return (string)$this->scopeConfig->getValue(self::XML_PATH_REDIRECT_PATH);
     }
 
     /**
@@ -204,7 +205,7 @@ class Config
      */
     public function getCurrency(): string
     {
-        return (string) $this->scopeConfig->getValue(Currency::XML_PATH_CURRENCY_BASE, ScopeInterface::SCOPE_WEBSITE);
+        return (string)$this->scopeConfig->getValue(Currency::XML_PATH_CURRENCY_BASE, ScopeInterface::SCOPE_WEBSITE);
     }
 
     /**
@@ -245,10 +246,10 @@ class Config
     public function getBaseUrl(): string
     {
         if ($this->getMode() === Mode::STAGING_MODE) {
-            return (string) $this->scopeConfig->getValue(self::XML_CONFIG_PATH_STAGING_BASE_URL);
+            return (string)$this->scopeConfig->getValue(self::XML_CONFIG_PATH_STAGING_BASE_URL);
         }
 
-        return (string) $this->scopeConfig->getValue(self::XML_CONFIG_PATH_PROD_BASE_URL);
+        return (string)$this->scopeConfig->getValue(self::XML_CONFIG_PATH_PROD_BASE_URL);
     }
 
     /**
@@ -256,7 +257,7 @@ class Config
      */
     public function getApiBasePath(): string
     {
-        return (string) $this->scopeConfig->getValue(self::XML_CONFIG_PATH_API_BASE_PATH);
+        return (string)$this->scopeConfig->getValue(self::XML_CONFIG_PATH_API_BASE_PATH);
     }
 
     /**
@@ -283,7 +284,7 @@ class Config
 
         $replacementData = array_merge([':sellerId' => $this->getSellerId()], $replacementData);
 
-        $apiPath = trim((string) $this->scopeConfig->getValue(self::ENDPOINT_CONFIG_MAPPING[$type]), '/');
+        $apiPath = trim((string)$this->scopeConfig->getValue(self::ENDPOINT_CONFIG_MAPPING[$type]), '/');
         $matches = [];
         if (preg_match('~(\:\w+)~', $apiPath, $matches)) {
             $matches = array_unique($matches);

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Iwoca\Iwocapay\Model;
 
+use Iwoca\Iwocapay\Model\Config\Checkout\ConfigProvider;
 use Iwoca\Iwocapay\Model\Config\Source\Mode;
 use Iwoca\Iwocapay\Model\Config\Source\PaymentTerms;
 use Magento\Directory\Model\Currency;
@@ -19,8 +20,10 @@ class Config
     public const XML_CONFIG_PATH_SELLER_ACCESS_TOKEN = 'payment/iwocapay/seller_access_token';
     public const XML_CONFIG_PATH_SELLER_ID = 'payment/iwocapay/seller_id';
     public const XML_CONFIG_PATH_MODE = 'payment/iwocapay/mode';
-    public const XML_CONFIG_PATH_ALLOWED_PAYMENT_TERMS = 'payment/iwocapay/allowed_payment_terms';
-    public const XML_CONFIG_PATH_TITLE = 'payment/iwocapay/title';
+    public const XML_CONFIG_PATH_TITLE = 'payment/%s/title';
+    public const XML_CONFIG_PATH_SUBTITLE = 'payment/%s/subtitle';
+    public const XML_CONFIG_PATH_CALL_TO_ACTION = 'payment/%s/call_to_action';
+    public const XML_CONFIG_PATH_ALLOWED_PAYMENT_TERMS = 'payment/iwocapay/allowed_payment_terms'; // used for settings
     public const XML_CONFIG_PATH_DEBUG_MODE = 'payment/iwocapay/debug_mode';
     public const XML_PATH_SOURCE = 'payment/iwocapay/source';
     public const XML_PATH_REDIRECT_PATH = 'payment/iwocapay/redirect_path';
@@ -127,11 +130,49 @@ class Config
     }
 
     /**
+     * USED FOR GLOBAL SETTINGS
+     *
+     *
+     * @param string $methodCode
+     * @return array
+     */
+    public function getAllowedPaymentTermOptions(string $methodCode): array
+    {
+        if ($methodCode === ConfigProvider::CODE_PAY_NOW) {
+            return PaymentTerms::PAY_NOW;
+        }
+
+        return PaymentTerms::PAY_LATER;
+    }
+
+    /**
+     * @param string $methodCode
      * @return string
      */
-    public function getTitle(): string
+    public function getTitle(string $methodCode): string
     {
-        return (string) $this->scopeConfig->getValue(self::XML_CONFIG_PATH_TITLE, ScopeInterface::SCOPE_STORE);
+        $path = sprintf(self::XML_CONFIG_PATH_TITLE, $methodCode);
+        return (string) $this->scopeConfig->getValue($path, ScopeInterface::SCOPE_STORE);
+    }
+
+    /**
+     * @param string $methodCode
+     * @return string
+     */
+    public function getSubtitle(string $methodCode): string
+    {
+        $path = sprintf(self::XML_CONFIG_PATH_SUBTITLE, $methodCode);
+        return (string) $this->scopeConfig->getValue($path, ScopeInterface::SCOPE_STORE);
+    }
+
+    /**
+     * @param string $methodCode
+     * @return string
+     */
+    public function getCallToAction(string $methodCode): string
+    {
+        $path = sprintf(self::XML_CONFIG_PATH_CALL_TO_ACTION, $methodCode);
+        return (string) $this->scopeConfig->getValue($path, ScopeInterface::SCOPE_STORE);
     }
 
     /**

--- a/Model/Config/Checkout/ConfigProvider.php
+++ b/Model/Config/Checkout/ConfigProvider.php
@@ -37,10 +37,11 @@ class ConfigProvider implements ConfigProviderInterface
      * @param UrlInterface $urlBuilder
      */
     public function __construct(
-        Config $config,
-        Repository $assetRepository,
+        Config       $config,
+        Repository   $assetRepository,
         UrlInterface $urlBuilder
-    ) {
+    )
+    {
         $this->config = $config;
         $this->assetRepository = $assetRepository;
         $this->urlBuilder = $urlBuilder;

--- a/Model/Config/Checkout/ConfigProvider.php
+++ b/Model/Config/Checkout/ConfigProvider.php
@@ -12,7 +12,8 @@ use Magento\Framework\View\Asset\Repository;
 
 class ConfigProvider implements ConfigProviderInterface
 {
-    public const CODE = 'iwocapay';
+    public const CODE_PAY_LATER = 'iwocapay';
+    public const CODE_PAY_NOW = 'iwocapay_paynow';
 
     /**
      * @var Config
@@ -51,24 +52,40 @@ class ConfigProvider implements ConfigProviderInterface
      */
     public function getConfig()
     {
-        $config = [
+        $configPayLater = [
             'isActive' => $this->config->isActive(),
             'sellerAccessToken' => $this->config->getSellerAccessToken(),
             'sellerId' => $this->config->getSellerId(),
             'mode' => $this->config->getMode(),
-            'title' => $this->config->getTitle(),
+            'title' => $this->config->getTitle(self::CODE_PAY_LATER),
+            'subtitle' => $this->config->getSubtitle(self::CODE_PAY_LATER),
+            'call_to_action' => $this->config->getCallToAction(self::CODE_PAY_LATER),
             'currency' => $this->config->getCurrency(),
             'iconSrc' => $this->assetRepository->getUrlWithParams('Iwoca_Iwocapay::images/iwocapay-icon.png', []),
             'iwocaCreateOrderUrl' => $this->urlBuilder->getRouteUrl('iwocapay/process/createOrder'),
             'isPayLaterOnly' => $this->config->getAllowedPaymentTerms() === PaymentTerms::PAY_LATER,
             'minAmount' => PaymentTerms::PAY_LATER_MIN_AMOUNT,
             'maxAmount' => PaymentTerms::PAY_LATER_MAX_AMOUNT
-
+        ];
+        $configPayNow = [
+            'isActive' => $this->config->isActive(),
+            'sellerAccessToken' => $this->config->getSellerAccessToken(),
+            'sellerId' => $this->config->getSellerId(),
+            'mode' => $this->config->getMode(),
+            'title' => $this->config->getTitle(self::CODE_PAY_NOW),
+            'subtitle' => $this->config->getSubtitle(self::CODE_PAY_NOW),
+            'call_to_action' => $this->config->getCallToAction(self::CODE_PAY_NOW),
+            'currency' => $this->config->getCurrency(),
+            'iconSrc' => $this->assetRepository->getUrlWithParams('Iwoca_Iwocapay::images/iwocapay-icon.png', []),
+            'iwocaCreateOrderUrl' => $this->urlBuilder->getRouteUrl('iwocapay/process/createOrder'),
+            'minAmount' => 0, // no min amount for pay now
+            'maxAmount' => PaymentTerms::PAY_LATER_MAX_AMOUNT // TODO: check this amount
         ];
 
         return [
             'payment' => [
-                self::CODE => $config
+                self::CODE_PAY_LATER => $configPayLater,
+                self::CODE_PAY_NOW => $configPayNow
             ]
         ];
     }

--- a/Model/Config/Checkout/ConfigProvider.php
+++ b/Model/Config/Checkout/ConfigProvider.php
@@ -12,7 +12,8 @@ use Magento\Framework\View\Asset\Repository;
 
 class ConfigProvider implements ConfigProviderInterface
 {
-    public const CODE_PAY_LATER = 'iwocapay';
+    public const CODE_SHARED = 'iwocapay';
+    public const CODE_PAY_LATER = 'iwocapay_paylater';
     public const CODE_PAY_NOW = 'iwocapay_paynow';
 
     /**
@@ -52,38 +53,34 @@ class ConfigProvider implements ConfigProviderInterface
      */
     public function getConfig()
     {
-        $configPayLater = [
+        $configShared = [
             'isActive' => $this->config->isActive(),
             'sellerAccessToken' => $this->config->getSellerAccessToken(),
             'sellerId' => $this->config->getSellerId(),
             'mode' => $this->config->getMode(),
-            'title' => $this->config->getTitle(self::CODE_PAY_LATER),
-            'subtitle' => $this->config->getSubtitle(self::CODE_PAY_LATER),
-            'call_to_action' => $this->config->getCallToAction(self::CODE_PAY_LATER),
             'currency' => $this->config->getCurrency(),
             'iconSrc' => $this->assetRepository->getUrlWithParams('Iwoca_Iwocapay::images/iwocapay-icon.png', []),
             'iwocaCreateOrderUrl' => $this->urlBuilder->getRouteUrl('iwocapay/process/createOrder'),
             'isPayLaterOnly' => $this->config->getAllowedPaymentTerms() === PaymentTerms::PAY_LATER,
+        ];
+        $configPayLater = [
+            'title' => $this->config->getTitle(self::CODE_PAY_LATER),
+            'subtitle' => $this->config->getSubtitle(self::CODE_PAY_LATER),
+            'call_to_action' => $this->config->getCallToAction(self::CODE_PAY_LATER),
             'minAmount' => PaymentTerms::PAY_LATER_MIN_AMOUNT,
             'maxAmount' => PaymentTerms::PAY_LATER_MAX_AMOUNT
         ];
         $configPayNow = [
-            'isActive' => $this->config->isActive(),
-            'sellerAccessToken' => $this->config->getSellerAccessToken(),
-            'sellerId' => $this->config->getSellerId(),
-            'mode' => $this->config->getMode(),
             'title' => $this->config->getTitle(self::CODE_PAY_NOW),
             'subtitle' => $this->config->getSubtitle(self::CODE_PAY_NOW),
             'call_to_action' => $this->config->getCallToAction(self::CODE_PAY_NOW),
-            'currency' => $this->config->getCurrency(),
-            'iconSrc' => $this->assetRepository->getUrlWithParams('Iwoca_Iwocapay::images/iwocapay-icon.png', []),
-            'iwocaCreateOrderUrl' => $this->urlBuilder->getRouteUrl('iwocapay/process/createOrder'),
-            'minAmount' => 0, // no min amount for pay now
-            'maxAmount' => PaymentTerms::PAY_LATER_MAX_AMOUNT // TODO: check this amount
+            'minAmount' => PaymentTerms::PAY_NOW_MIN_AMOUNT,
+            'maxAmount' => PaymentTerms::PAY_NOW_MAX_AMOUNT
         ];
 
         return [
             'payment' => [
+                self::CODE_SHARED => $configShared,
                 self::CODE_PAY_LATER => $configPayLater,
                 self::CODE_PAY_NOW => $configPayNow
             ]

--- a/Model/Config/Source/PaymentTerms.php
+++ b/Model/Config/Source/PaymentTerms.php
@@ -11,6 +11,7 @@ class PaymentTerms implements OptionSourceInterface
 
     public const PAY_NOW_PAY_LATER = ['PAY_LATER', 'PAY_NOW'];
     public const PAY_LATER = ['PAY_LATER'];
+    public const PAY_NOW = ['PAY_NOW'];
     public const PAY_LATER_MIN_AMOUNT = 150;
     public const PAY_LATER_MAX_AMOUNT = 30000;
 

--- a/Model/Config/Source/PaymentTerms.php
+++ b/Model/Config/Source/PaymentTerms.php
@@ -14,6 +14,10 @@ class PaymentTerms implements OptionSourceInterface
     public const PAY_NOW = ['PAY_NOW'];
     public const PAY_LATER_MIN_AMOUNT = 150;
     public const PAY_LATER_MAX_AMOUNT = 30000;
+    public const PAY_NOW_MIN_AMOUNT = 0;
+    // Note: individual bank limits apply, however range from 25k - 30k, So align with Pay Later and let TrueLayer
+    // signpost based on individual account status.
+    public const PAY_NOW_MAX_AMOUNT = 30000;
 
     /**
      * @var Json

--- a/Observer/CustomerReturnObserver.php
+++ b/Observer/CustomerReturnObserver.php
@@ -39,27 +39,27 @@ It checks the following conditions:
     Set the allow_cancel_order flag to true
     (this allows the order to be canceled when the customer returns to the store via the back button)
 
-                Redirect                                           
-              - Referrer === Checkout location                   
-              - Redirect to outside store                        
+                Redirect
+              - Referrer === Checkout location
+              - Redirect to outside store
 +-----------+ => set allow_cancel_order flag to true +----------+
 | Checkout  +--------------------------------------> | iwocaPay |
 +-----------+                                        +----+-+---+
-     ^ ^                                                  | |    
-     | |                                                  | |    
-     | +--------------------------------------------------+ |    
-     |            Back Button                               |    
-     |            - Location === Checkout || Cart           |    
-     |            - allow_cancel_order === true             |    
-     |            => Cancel latest iwocaPay order           |    
-     |            => Recreate latest iwocaPay quote         |    
-     |                                                      |    
-  +--+----+                                                 |    
-  | Store | <-----------------------------------------------+    
-  +-------+    Navigation                                        
-               - No referrer                                     
-               - Location !== Checkout || Cart                   
-               => set allow_cancel_order_flag to false           
+     ^ ^                                                  | |
+     | |                                                  | |
+     | +--------------------------------------------------+ |
+     |            Back Button                               |
+     |            - Location === Checkout || Cart           |
+     |            - allow_cancel_order === true             |
+     |            => Cancel latest iwocaPay order           |
+     |            => Recreate latest iwocaPay quote         |
+     |                                                      |
+  +--+----+                                                 |
+  | Store | <-----------------------------------------------+
+  +-------+    Navigation
+               - No referrer
+               - Location !== Checkout || Cart
+               => set allow_cancel_order_flag to false
  */
 
 class CustomerReturnObserver implements ObserverInterface
@@ -168,7 +168,12 @@ class CustomerReturnObserver implements ObserverInterface
         $order = $this->orderFactory->create()->load($orderId);
         $payment = $order->getPayment();
 
-        if (!$payment || $payment->getMethod() !== 'iwocapay') return;
+        if (
+            !$payment ||
+            !in_array($payment->getMethod(), ['iwocapay', 'iwocapay_paylater', 'iwocapay_paynow'], true)
+        ) {
+            return;
+        }
 
         if ($order->getStatus() !== \Magento\Sales\Model\Order::STATE_PENDING_PAYMENT) return;
 

--- a/Observer/CustomerReturnObserver.php
+++ b/Observer/CustomerReturnObserver.php
@@ -111,13 +111,13 @@ class CustomerReturnObserver implements ObserverInterface
      * @param RequestInterface $request
      */
     public function __construct(
-        LoggerInterface $logger,
-        QuoteRepository $quoteRepository,
-        CheckoutSession $checkoutSession,
-        OrderFactory $orderFactory,
-        PageIdentifier $pageIdentifier,
+        LoggerInterface         $logger,
+        QuoteRepository         $quoteRepository,
+        CheckoutSession         $checkoutSession,
+        OrderFactory            $orderFactory,
+        PageIdentifier          $pageIdentifier,
         CartRepositoryInterface $cartRepository,
-        RequestInterface $request,
+        RequestInterface        $request,
     ) {
         $this->logger = $logger;
         $this->quoteRepository = $quoteRepository;

--- a/Observer/DisableOrderEmailBeforeQuoteSubmit.php
+++ b/Observer/DisableOrderEmailBeforeQuoteSubmit.php
@@ -21,7 +21,14 @@ class DisableOrderEmailBeforeQuoteSubmit implements ObserverInterface
         /** @var Quote $quote */
         $quote = $event->getQuote();
 
-        if ($quote->getPayment()->getMethod() !== ConfigProvider::CODE_PAY_LATER && $quote->getPayment()->getMethod() !== ConfigProvider::CODE_PAY_NOW && $quote->getPayment()->getMethod() !== ConfigProvider::CODE_SHARED) {
+        $method = $quote->getPayment()->getMethod();
+        $validMethods = [
+            ConfigProvider::CODE_PAY_LATER,
+            ConfigProvider::CODE_PAY_NOW,
+            ConfigProvider::CODE_SHARED,
+        ];
+
+        if (!in_array($method, $validMethods, true)) {
             return $observer;
         }
 

--- a/Observer/DisableOrderEmailBeforeQuoteSubmit.php
+++ b/Observer/DisableOrderEmailBeforeQuoteSubmit.php
@@ -21,7 +21,7 @@ class DisableOrderEmailBeforeQuoteSubmit implements ObserverInterface
         /** @var Quote $quote */
         $quote = $event->getQuote();
 
-        if ($quote->getPayment()->getMethod() !== ConfigProvider::CODE) {
+        if ($quote->getPayment()->getMethod() !== ConfigProvider::CODE_PAY_LATER && $quote->getPayment()->getMethod() !== ConfigProvider::CODE_PAY_NOW) {
             return $observer;
         }
 

--- a/Observer/DisableOrderEmailBeforeQuoteSubmit.php
+++ b/Observer/DisableOrderEmailBeforeQuoteSubmit.php
@@ -21,7 +21,7 @@ class DisableOrderEmailBeforeQuoteSubmit implements ObserverInterface
         /** @var Quote $quote */
         $quote = $event->getQuote();
 
-        if ($quote->getPayment()->getMethod() !== ConfigProvider::CODE_PAY_LATER && $quote->getPayment()->getMethod() !== ConfigProvider::CODE_PAY_NOW) {
+        if ($quote->getPayment()->getMethod() !== ConfigProvider::CODE_PAY_LATER && $quote->getPayment()->getMethod() !== ConfigProvider::CODE_PAY_NOW && $quote->getPayment()->getMethod() !== ConfigProvider::CODE_SHARED) {
             return $observer;
         }
 

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -3,7 +3,9 @@
     <default>
         <payment>
             <iwocapay>
-                <title>Pay Later options for businesses</title>
+                <title>Pay Later with iwocaPay</title>
+                <subtitle>Trade Credit for LTD companies, powered by iwocaPay. Applying won't affect your credit score.</subtitle>
+                <call_to_action>Pay Later</call_to_action>
                 <mode>0</mode>
                 <group>iwoca</group>
                 <model>IwocapayFacade</model>
@@ -18,6 +20,24 @@
                 <allowed_payment_terms><![CDATA[["PAY_LATER", "PAY_NOW"]]]></allowed_payment_terms>
                 <allowed_currencies><![CDATA[["GBP"]]]></allowed_currencies>
             </iwocapay>
+            <iwocapay_paynow>
+                <title>Pay Now with iwocaPay</title>
+                <subtitle>Instant, secure, bank-to-bank payments, powered by iwocaPay.</subtitle>
+                <call_to_action>Pay Now</call_to_action>
+                <mode>0</mode>
+                <group>iwoca</group>
+                <model>IwocapaynowFacade</model>
+                <prod_base_url>https://www.iwoca.co.uk</prod_base_url>
+                <staging_base_url>https://stage.iwoca-dev.co.uk</staging_base_url>
+                <api_base_path>/api/lending/edge/</api_base_path>
+                <api_path_create_order><![CDATA[/ecommerce/seller/:sellerId/order]]></api_path_create_order>
+                <api_path_get_order><![CDATA[/ecommerce/order/:orderId]]></api_path_get_order>
+                <can_use_checkout>1</can_use_checkout>
+                <source>iwocaPay_magento_extension</source>
+                <redirect_path>iwocapay/process/callback</redirect_path>
+                <allowed_payment_terms><![CDATA[["PAY_LATER", "PAY_NOW"]]]></allowed_payment_terms>
+                <allowed_currencies><![CDATA[["GBP"]]]></allowed_currencies>
+            </iwocapay_paynow>
         </payment>
     </default>
 </config>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -3,9 +3,6 @@
     <default>
         <payment>
             <iwocapay>
-                <title>Pay Later with iwocaPay</title>
-                <subtitle>Trade Credit for LTD companies, powered by iwocaPay. Applying won't affect your credit score.</subtitle>
-                <call_to_action>Pay Later</call_to_action>
                 <mode>0</mode>
                 <group>iwoca</group>
                 <model>IwocapayFacade</model>
@@ -20,23 +17,17 @@
                 <allowed_payment_terms><![CDATA[["PAY_LATER", "PAY_NOW"]]]></allowed_payment_terms>
                 <allowed_currencies><![CDATA[["GBP"]]]></allowed_currencies>
             </iwocapay>
+            <iwocapay_paylater>
+                <title>Pay Later with iwocaPay</title>
+                <subtitle>Trade Credit for LTD companies, powered by iwocaPay. Applying won't affect your credit score.</subtitle>
+                <call_to_action>Pay Later</call_to_action>
+                <model>IwocapayFacade</model>
+            </iwocapay_paylater>
             <iwocapay_paynow>
                 <title>Pay Now with iwocaPay</title>
                 <subtitle>Instant, secure, bank-to-bank payments, powered by iwocaPay.</subtitle>
                 <call_to_action>Pay Now</call_to_action>
-                <mode>0</mode>
-                <group>iwoca</group>
                 <model>IwocapaynowFacade</model>
-                <prod_base_url>https://www.iwoca.co.uk</prod_base_url>
-                <staging_base_url>https://stage.iwoca-dev.co.uk</staging_base_url>
-                <api_base_path>/api/lending/edge/</api_base_path>
-                <api_path_create_order><![CDATA[/ecommerce/seller/:sellerId/order]]></api_path_create_order>
-                <api_path_get_order><![CDATA[/ecommerce/order/:orderId]]></api_path_get_order>
-                <can_use_checkout>1</can_use_checkout>
-                <source>iwocaPay_magento_extension</source>
-                <redirect_path>iwocapay/process/callback</redirect_path>
-                <allowed_payment_terms><![CDATA[["PAY_LATER", "PAY_NOW"]]]></allowed_payment_terms>
-                <allowed_currencies><![CDATA[["GBP"]]]></allowed_currencies>
             </iwocapay_paynow>
         </payment>
     </default>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -38,7 +38,7 @@
     </virtualType>
     <virtualType name="IwocapayMethodConfig" type="Magento\Payment\Gateway\Config\Config">
         <arguments>
-            <argument name="methodCode" xsi:type="const">Iwoca\Iwocapay\Model\Config\Checkout\ConfigProvider::CODE_PAY_LATER</argument>
+            <argument name="methodCode" xsi:type="const">Iwoca\Iwocapay\Model\Config\Checkout\ConfigProvider::CODE_SHARED</argument>
         </arguments>
     </virtualType>
 

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -7,7 +7,16 @@
 
     <virtualType name="IwocapayFacade" type="Magento\Payment\Model\Method\Adapter">
         <arguments>
-            <argument name="code" xsi:type="const">Iwoca\Iwocapay\Model\Config\Checkout\ConfigProvider::CODE</argument>
+            <argument name="code" xsi:type="const">Iwoca\Iwocapay\Model\Config\Checkout\ConfigProvider::CODE_PAY_LATER</argument>
+            <argument name="formBlockType" xsi:type="string">Magento\Payment\Block\Form</argument>
+            <argument name="infoBlockType" xsi:type="string">Magento\Payment\Block\Info</argument>
+            <argument name="valueHandlerPool" xsi:type="object">IwocapayValueHandlerPool</argument>
+            <argument name="validatorPool" xsi:type="object">IwocapayValidatorPool</argument>
+        </arguments>
+    </virtualType>
+    <virtualType name="IwocapaynowFacade" type="Magento\Payment\Model\Method\Adapter">
+        <arguments>
+            <argument name="code" xsi:type="const">Iwoca\Iwocapay\Model\Config\Checkout\ConfigProvider::CODE_PAY_NOW</argument>
             <argument name="formBlockType" xsi:type="string">Magento\Payment\Block\Form</argument>
             <argument name="infoBlockType" xsi:type="string">Magento\Payment\Block\Info</argument>
             <argument name="valueHandlerPool" xsi:type="object">IwocapayValueHandlerPool</argument>
@@ -29,7 +38,7 @@
     </virtualType>
     <virtualType name="IwocapayMethodConfig" type="Magento\Payment\Gateway\Config\Config">
         <arguments>
-            <argument name="methodCode" xsi:type="const">Iwoca\Iwocapay\Model\Config\Checkout\ConfigProvider::CODE</argument>
+            <argument name="methodCode" xsi:type="const">Iwoca\Iwocapay\Model\Config\Checkout\ConfigProvider::CODE_PAY_LATER</argument>
         </arguments>
     </virtualType>
 

--- a/etc/payment.xml
+++ b/etc/payment.xml
@@ -10,5 +10,8 @@
         <method name="iwocapay">
             <allow_multiple_address>1</allow_multiple_address>
         </method>
+        <method name="iwocapay_paynow">
+            <allow_multiple_address>1</allow_multiple_address>
+        </method>
     </methods>
 </payment>

--- a/view/frontend/layout/checkout_index_index.xml
+++ b/view/frontend/layout/checkout_index_index.xml
@@ -21,6 +21,9 @@
                                                                         <item name="iwocapay" xsi:type="array">
                                                                             <item name="isBillingAddressRequired" xsi:type="boolean">true</item>
                                                                         </item>
+                                                                        <item name="iwocapay_paynow" xsi:type="array">
+                                                                            <item name="isBillingAddressRequired" xsi:type="boolean">true</item>
+                                                                        </item>
                                                                     </item>
                                                                 </item>
                                                             </item>

--- a/view/frontend/web/js/view/payment/iwocapay.js
+++ b/view/frontend/web/js/view/payment/iwocapay.js
@@ -1,54 +1,54 @@
 define([
-    'uiComponent',
-    'Magento_Checkout/js/model/payment/renderer-list',
-    'Magento_Checkout/js/model/quote'
-],
-function (Component, rendererList, quote) {
-    'use strict';
+        'uiComponent',
+        'Magento_Checkout/js/model/payment/renderer-list',
+        'Magento_Checkout/js/model/quote'
+    ],
+    function (Component, rendererList, quote) {
+        'use strict';
 
-    let config = window.checkoutConfig.payment;
+        var config = window.checkoutConfig.payment;
 
-    // - do we have all the payment keys that we need?
-    if (!['iwocapay', 'iwocapay_paylater', 'iwocapay_paynow'].every(key => key in config)) {
-        return Component.extend({});
-    }
+        // - do we have all the payment keys that we need?
+        var requiredKeys = ['iwocapay', 'iwocapay_paylater', 'iwocapay_paynow'];
+        for (var i = 0; i < requiredKeys.length; i++) {
+            if (!(requiredKeys[i] in config)) {
+                return Component.extend({});
+            }
+        }
 
-    // - is iwocapay enabled?
-    let payLater = config.iwocapay_paylater,
-        payNow = config.iwocapay_paynow,
-        shared = config.iwocapay,
-        isActive = shared.isActive;
+        // - is iwocapay enabled?
+        var payLater = config.iwocapay_paylater;
+        var payNow = config.iwocapay_paynow;
+        var shared = config.iwocapay;
+        var isActive = shared.isActive;
 
-    if (!isActive) {
-        return Component.extend({});
-    }
+        if (!isActive) {
+            return Component.extend({});
+        }
 
-    // - verify max and min amounts
-    let quoteGrandTotal = quote.totals()['grand_total'],
-        minPayLater = payLater.minAmount,
-        maxPayLater = payLater.maxAmount,
-        minPayNow = payNow.minAmount,
-        maxPayNow = payNow.maxAmount;
+        // - verify max and min amounts
+        var quoteGrandTotal = quote.totals()['grand_total'];
+        var minPayLater = payLater.minAmount;
+        var maxPayLater = payLater.maxAmount;
+        var minPayNow = payNow.minAmount;
+        var maxPayNow = payNow.maxAmount;
 
-    // - pay later
-    if (quoteGrandTotal >= minPayLater && quoteGrandTotal <= maxPayLater) {
-        rendererList.push(
-            {
+        // - pay later
+        if (quoteGrandTotal >= minPayLater && quoteGrandTotal <= maxPayLater) {
+            rendererList.push({
                 type: 'iwocapay_paylater',
                 component: 'Iwoca_Iwocapay/js/view/payment/method-renderer/iwocapay'
-            }
-        );
-    }
+            });
+        }
 
-    // - pay now
-    if (!config.iwocapay.isPayLaterOnly && quoteGrandTotal >= minPayNow && quoteGrandTotal <= maxPayNow) {
-        rendererList.push(
-            {
+        // - pay now
+        if (!shared.isPayLaterOnly && quoteGrandTotal >= minPayNow && quoteGrandTotal <= maxPayNow) {
+            rendererList.push({
                 type: 'iwocapay_paynow',
                 component: 'Iwoca_Iwocapay/js/view/payment/method-renderer/iwocapay'
-            }
-        );
-    }
+            });
+        }
 
-    return Component.extend({});
-});
+        return Component.extend({});
+    }
+);

--- a/view/frontend/web/js/view/payment/iwocapay.js
+++ b/view/frontend/web/js/view/payment/iwocapay.js
@@ -28,6 +28,14 @@ function (Component, rendererList, quote) {
                     component: 'Iwoca_Iwocapay/js/view/payment/method-renderer/iwocapay'
                 }
             );
+            if (!window.checkoutConfig.payment.iwocapay.isPayLaterOnly) {
+                rendererList.push(
+                    {
+                        type: 'iwocapay_paynow',
+                        component: 'Iwoca_Iwocapay/js/view/payment/method-renderer/iwocapay'
+                    }
+                );
+            }
         }
     }
 

--- a/view/frontend/web/js/view/payment/method-renderer/iwocapay.js
+++ b/view/frontend/web/js/view/payment/method-renderer/iwocapay.js
@@ -34,6 +34,30 @@ define([
          */
         getIwocapayIconSrc: function () {
             return window.checkoutConfig.payment.iwocapay.iconSrc;
+        },
+
+        /**
+         * Retrieve the payment option title from the config.
+         * @return string
+         */
+        getPaymentOptionTitle: function () {
+            return window.checkoutConfig.payment[this.getCode()].title;
+        },
+
+        /**
+         * Retrieve the payment option subtitle from the config.
+         * @return string
+         */
+        getPaymentOptionSubtitle: function () {
+            return window.checkoutConfig.payment[this.getCode()].subtitle;
+        },
+
+        /**
+         * Retrieve the payment option button title from the config.
+         * @return string
+         */
+        getPaymentOptionCallToAction: function () {
+            return window.checkoutConfig.payment[this.getCode()].call_to_action;
         }
     });
 });

--- a/view/frontend/web/template/payment/iwocapay/form.html
+++ b/view/frontend/web/template/payment/iwocapay/form.html
@@ -7,7 +7,7 @@
         <label data-bind="attr: {'for': getCode()}" class="icon-container">
             <img data-bind="attr: {src: getIwocapayIconSrc(), alt: $t('Iwocapay')}"
                  class="payment-icon"/>
-            <span data-bind="text: getTitle()"></span>
+            <span data-bind="text: getPaymentOptionTitle()"></span>
         </label>
     </div>
     <div class="payment-method-content">
@@ -16,7 +16,7 @@
         <!--/ko-->
         <fieldset class="fieldset" data-bind='attr: {id: "payment_form_" + getCode()}'>
             <div class="payment-method-note">
-                <!-- ko i18n: 'Credit option for LTD companies, powered by iwocaPay. You will be redirected to complete your payment' --><!-- /ko -->
+                <!-- ko i18n: getPaymentOptionSubtitle() --><!-- /ko -->
             </div>
         </fieldset>
         <div class="checkout-agreements-block">
@@ -30,7 +30,7 @@
                         type="submit"
                         data-bind="click: placeOrder, enable: (getCode() == isChecked())"
                         disabled>
-                    <span data-bind="i18n: 'Pay with iwocaPay'"></span>
+                    <span data-bind="i18n: getPaymentOptionCallToAction()"></span>
                 </button>
             </div>
         </div>


### PR DESCRIPTION
Splits the iwocaPay checkout into two options. Pay Later and Pay Now. Backwards compatible and configurable options via the admin pages.