### PR TITLE
fix: wait for customer-data initialization before reload

### DIFF
--- a/view/frontend/web/js/reload-mini-cart.js
+++ b/view/frontend/web/js/reload-mini-cart.js
@@ -1,16 +1,15 @@
-require(["jquery", "Magento_Customer/js/customer-data"], function (
-  $,
-  customerData
-) {
-  "use strict";
+require(["jquery", "Magento_Customer/js/customer-data", "domReady!"], function ($, customerData) {
+    "use strict";
 
-  $(document).ready(function () {
-    const isCartPage = window.location.href.includes("checkout/cart");
-    const cartElementExists = $(".cart-container").length > 0;
-    const isCart = isCartPage || cartElementExists;
-
-    if (!isCart) return;
-
-    customerData.reload(["cart"], true);
-  });
+    const isCartPage = window.location.href.includes("checkout/cart");                                                                                                                                                         
+    const cartElementExists = $(".cart-container").length > 0;                                                                                                                                                                 
+    const isCart = isCartPage || cartElementExists;                                                                                                                                                                            
+                                                                                                                                                                                                                               
+    if (!isCart) {
+        return;
+    }
+                                                
+    customerData.getInitCustomerData().done(function () {                                                                                                                                                                      
+        customerData.reload(["cart"], true);                                                                                                                                                                                     
+    });
 });


### PR DESCRIPTION
## Problem

The `reload-mini-cart.js` script calls `customerData.reload(['cart'], true)` immediately when the page loads. However, on certain pages, the customer-data module may not be fully initialized yet, causing a JavaScript error:

Uncaught TypeError: Cannot read properties of undefined (reading 'set')                                                                                                                                                      
at customer-data.js:180:25                                                                                                                                                                                               
at _$1.each (underscore.js:1335:17)                                                                                                                                                                                      
at Object.update (customer-data.js:177:15)

This happens because the storage sections haven't been initialized when `reload()` is called.

## Solution

Use the `getInitCustomerData()` promise provided by Magento's customer-data module to wait for initialization before calling `reload()`. This ensures the cart section storage is properly set up before attempting to reload it.

## Changes
- Replaced `$(document).ready()` with `domReady!` RequireJS plugin for cleaner dependency handling
- Wrapped `customerData.reload()` call inside `customerData.getInitCustomerData().done()` callback