### PR TITLE
Add hmac validation to callback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 __MACOSX/
 [Tt]humbs.db
 *.DS_Store
+settings.json

--- a/Controller/Process/Callback.php
+++ b/Controller/Process/Callback.php
@@ -401,10 +401,6 @@ class Callback implements HttpGetActionInterface
      */
     private function addDebugLog(string $logMessage): void
     {
-        if (!$this->config->isDebugModeEnabled()) {
-            return;
-        }
-
         $this->logger->debug($logMessage);
     }
 }

--- a/Controller/Process/Callback.php
+++ b/Controller/Process/Callback.php
@@ -6,9 +6,7 @@ namespace Iwoca\Iwocapay\Controller\Process;
 
 use GuzzleHttp\Exception\GuzzleException;
 use Iwoca\Iwocapay\Api\Response\GetOrderInterface;
-use Iwoca\Iwocapay\Api\Response\GetOrderInterfaceFactory;
-use Iwoca\Iwocapay\Model\Config;
-use Iwoca\Iwocapay\Model\IwocaClientFactory;
+use Iwoca\Iwocapay\Model\IwocaApiClient;
 use Magento\Checkout\Model\Session;
 use Magento\Framework\App\Action\Context;
 use Magento\Framework\App\Action\HttpGetActionInterface;
@@ -38,10 +36,7 @@ class Callback implements HttpGetActionInterface
 
     private Context $context;
     private ResultFactory $resultFactory;
-    private Config $config;
-    private IwocaClientFactory $iwocaClientFactory;
-    private Json $jsonSerializer;
-    private GetOrderInterfaceFactory $getOrderFactory;
+    private IwocaApiClient $iwocaApiClient;
     private Session $checkoutSession;
     private OrderFactory $orderFactory;
     private OrderRepositoryInterface $orderRepository;
@@ -58,10 +53,7 @@ class Callback implements HttpGetActionInterface
     /**
      * @param Context $context
      * @param ResultFactory $resultFactory
-     * @param Config $config
-     * @param IwocaClientFactory $iwocaClientFactory
-     * @param Json $jsonSerializer
-     * @param GetOrderInterfaceFactory $getOrderFactory
+     * @param IwocaApiClient $iwocaApiClient
      * @param Session $checkoutSession
      * @param OrderFactory $orderFactory
      * @param OrderRepositoryInterface $orderRepository
@@ -69,16 +61,16 @@ class Callback implements HttpGetActionInterface
      * @param CartRepositoryInterface $quoteRepository
      * @param InvoiceService $invoiceService
      * @param InvoiceRepositoryInterface $invoiceRepository
+     * @param InvoiceSender $invoiceSender
      * @param OrderSender $orderSender
      * @param LoggerInterface $logger
+     * @param ScopeConfigInterface $scopeConfig
+     * @param PaymentCollectionFactory $paymentCollectionFactory
      */
     public function __construct(
         Context $context,
         ResultFactory $resultFactory,
-        Config $config,
-        IwocaClientFactory $iwocaClientFactory,
-        Json $jsonSerializer,
-        GetOrderInterfaceFactory $getOrderFactory,
+        IwocaApiClient $iwocaApiClient,
         Session $checkoutSession,
         OrderFactory $orderFactory,
         OrderRepositoryInterface $orderRepository,
@@ -94,10 +86,7 @@ class Callback implements HttpGetActionInterface
     ) {
         $this->context = $context;
         $this->resultFactory = $resultFactory;
-        $this->config = $config;
-        $this->iwocaClientFactory = $iwocaClientFactory;
-        $this->jsonSerializer = $jsonSerializer;
-        $this->getOrderFactory = $getOrderFactory;
+        $this->iwocaApiClient = $iwocaApiClient;
         $this->checkoutSession = $checkoutSession;
         $this->orderFactory = $orderFactory;
         $this->orderRepository = $orderRepository;
@@ -129,7 +118,7 @@ class Callback implements HttpGetActionInterface
         }
 
         try {
-            $orderResponse = $this->getIwocaOrderResponse($iwocaOrderId);
+            $orderResponse = $this->iwocaApiClient->getOrder($iwocaOrderId);
         } catch (GuzzleException | LocalizedException $e) {
             $this->logger->error('iwocaPay callback: Failed to get order response - ' . $e->getMessage());
             return $this->handleFailure($redirect);
@@ -168,51 +157,6 @@ class Callback implements HttpGetActionInterface
         $this->handleSuccess($magentoOrder, $orderResponse);
 
         return $redirect->setUrl('/checkout/onepage/success');
-    }
-
-    /**
-     * @param string $iwocaOrderId
-     * @return GetOrderInterface
-     * @throws GuzzleException
-     * @throws LocalizedException
-     */
-    private function getIwocaOrderResponse(string $iwocaOrderId): GetOrderInterface
-    {
-        $iwocaClient = $this->iwocaClientFactory->create();
-        try {
-            $rawResponse = $iwocaClient->get(
-                $this->config->getApiEndpoint(
-                    Config::CONFIG_TYPE_GET_ORDER_ENDPOINT,
-                    [':' . self::IWOCA_ORDER_ID_PARAM => $iwocaOrderId]
-                )
-            );
-        } catch (GuzzleException $e) {
-            $this->addDebugLog(
-                sprintf(
-                    'Error occurred while retrieving Iwoca order response for order with Iwoca ID %s. Received exception %s',
-                    $iwocaOrderId,
-                    $e->getMessage()
-                )
-            );
-            throw $e;
-        } catch (LocalizedException $e) {
-            $this->addDebugLog(
-                sprintf(
-                    'Error occurred while getting API endpoint of type "%s". Exception: %s',
-                    Config::CONFIG_TYPE_GET_ORDER_ENDPOINT,
-                    $e->getMessage()
-                )
-            );
-            throw $e;
-        }
-
-        $responseJson = $rawResponse->getBody()->getContents();
-        $responseData = $this->jsonSerializer->unserialize($responseJson);
-
-        $orderResponse = $this->getOrderFactory->create();
-        $orderResponse->setData($responseData['data']);
-
-        return $orderResponse;
     }
 
     /**

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -34,7 +34,8 @@ class Config
     public const XML_CONFIG_PATH_ALLOWED_CURRENCIES = 'payment/iwocapay/allowed_currencies';
     public const XML_CONFIG_PATH_STAGING_BASE_URL = 'payment/iwocapay/staging_base_url';
     public const XML_CONFIG_PATH_PROD_BASE_URL = 'payment/iwocapay/prod_base_url';
-    public const XML_CONFIG_PATH_API_BASE_PATH = 'payment/iwocapay/api_base_path';
+    public const XML_CONFIG_PATH_API_BASE_PATH_LENDING = 'payment/iwocapay/api_base_path_lending';
+    public const XML_CONFIG_PATH_API_BASE_PATH_IWOCAPAY = 'payment/iwocapay/api_base_path_iwocapay';
     public const XML_CONFIG_PATH_API_PATH_CREATE_ORDER = 'payment/iwocapay/api_path_create_order';
     public const XML_CONFIG_PATH_API_PATH_GET_ORDER = 'payment/iwocapay/api_path_get_order';
 
@@ -43,6 +44,10 @@ class Config
     public const ENDPOINT_CONFIG_MAPPING = [
         self::CONFIG_TYPE_CREATE_ORDER_ENDPOINT => self::XML_CONFIG_PATH_API_PATH_CREATE_ORDER,
         self::CONFIG_TYPE_GET_ORDER_ENDPOINT => self::XML_CONFIG_PATH_API_PATH_GET_ORDER
+    ];
+    public const ENDPOINT_BASE_PATH_MAPPING = [
+        self::CONFIG_TYPE_CREATE_ORDER_ENDPOINT => self::XML_CONFIG_PATH_API_BASE_PATH_LENDING,
+        self::CONFIG_TYPE_GET_ORDER_ENDPOINT => self::XML_CONFIG_PATH_API_BASE_PATH_IWOCAPAY
     ];
 
     /**
@@ -263,20 +268,23 @@ class Config
     }
 
     /**
+     * @param string $endpointType
      * @return string
      */
-    public function getApiBasePath(): string
+    public function getApiBasePath(string $endpointType): string
     {
-        return (string)$this->scopeConfig->getValue(self::XML_CONFIG_PATH_API_BASE_PATH);
+        $basePathConfig = self::ENDPOINT_BASE_PATH_MAPPING[$endpointType] ?? self::XML_CONFIG_PATH_API_BASE_PATH_LENDING;
+        return (string)$this->scopeConfig->getValue($basePathConfig);
     }
 
     /**
+     * @param string $endpointType
      * @return string
      */
-    public function getApiBaseUrl(): string
+    public function getApiBaseUrl(string $endpointType): string
     {
         $baseUrl = rtrim($this->getBaseUrl(), '/');
-        $basePath = trim($this->getApiBasePath(), '/');
+        $basePath = trim($this->getApiBasePath($endpointType), '/');
         return $baseUrl . '/' . $basePath;
     }
 
@@ -296,8 +304,8 @@ class Config
 
         $apiPath = trim((string)$this->scopeConfig->getValue(self::ENDPOINT_CONFIG_MAPPING[$type]), '/');
         $matches = [];
-        if (preg_match('~(\:\w+)~', $apiPath, $matches)) {
-            $matches = array_unique($matches);
+        if (preg_match_all('~(\:\w+)~', $apiPath, $matches)) {
+            $matches = array_unique($matches[1]);
             foreach ($matches as $match) {
                 if (isset($replacementData[$match])) {
                     $apiPath = str_replace($match, $replacementData[$match], $apiPath);
@@ -305,7 +313,7 @@ class Config
             }
         }
 
-        return $this->getApiBaseUrl() . '/' . $apiPath . '/';
+        return $this->getApiBaseUrl($type) . '/' . $apiPath . '/';
     }
 
     /**

--- a/Model/Hmac.php
+++ b/Model/Hmac.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace Iwoca\Iwocapay\Model;
+
+class Hmac
+{
+    /**
+     * Compute HMAC-SHA256 signature.
+     *
+     * @param string $data The data to hash (raw JSON response body)
+     * @param string $hashKey The secret key (seller access token)
+     * @return string Base64-encoded HMAC signature
+     */
+    public function computeHmac(string $data, string $hashKey): string
+    {
+        // hash_hmac with raw_output=true returns binary data (like Python's digest())
+        $digest = hash_hmac('sha256', $data, $hashKey, true);
+
+        // base64_encode converts to the same format as Python
+        return base64_encode($digest);
+    }
+
+    /**
+     * Verify HMAC signature using timing-safe comparison
+     *
+     * @param string $expectedHmac The HMAC from the response header
+     * @param string $computedHmac The HMAC we computed from the body
+     * @return bool True if HMACs match, false otherwise
+     */
+    public function verifyHmac(string $expectedHmac, string $computedHmac): bool
+    {
+        // Use hash_equals for timing-safe comparison to prevent timing attacks
+        return hash_equals($expectedHmac, $computedHmac);
+    }
+}

--- a/Model/IwocaApiClient.php
+++ b/Model/IwocaApiClient.php
@@ -1,0 +1,79 @@
+<?php
+declare(strict_types=1);
+
+namespace Iwoca\Iwocapay\Model;
+
+use GuzzleHttp\Exception\GuzzleException;
+use Iwoca\Iwocapay\Api\Response\GetOrderInterface;
+use Iwoca\Iwocapay\Api\Response\GetOrderInterfaceFactory;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Serialize\Serializer\Json;
+
+/**
+ * High-level client for iwoca API endpoints
+ */
+class IwocaApiClient
+{
+    private IwocaClientFactory $clientFactory;
+    private ?IwocaClient $client = null;
+    private Config $config;
+    private Json $jsonSerializer;
+    private GetOrderInterfaceFactory $getOrderFactory;
+
+    /**
+     * @param IwocaClientFactory $clientFactory
+     * @param Config $config
+     * @param Json $jsonSerializer
+     * @param GetOrderInterfaceFactory $getOrderFactory
+     */
+    public function __construct(
+        IwocaClientFactory $clientFactory,
+        Config $config,
+        Json $jsonSerializer,
+        GetOrderInterfaceFactory $getOrderFactory
+    ) {
+        $this->clientFactory = $clientFactory;
+        $this->config = $config;
+        $this->jsonSerializer = $jsonSerializer;
+        $this->getOrderFactory = $getOrderFactory;
+    }
+
+    /**
+     * Get the IwocaClient instance (lazy initialization, reused)
+     *
+     * @return IwocaClient
+     */
+    private function getClient(): IwocaClient
+    {
+        if ($this->client === null) {
+            $this->client = $this->clientFactory->create();
+        }
+        return $this->client;
+    }
+
+    /**
+     * Get order from iwoca API
+     *
+     * @param string $orderId
+     * @return GetOrderInterface
+     * @throws GuzzleException
+     * @throws LocalizedException
+     */
+    public function getOrder(string $orderId): GetOrderInterface
+    {
+        $rawResponse = $this->getClient()->get(
+            $this->config->getApiEndpoint(
+                Config::CONFIG_TYPE_GET_ORDER_ENDPOINT,
+                [':orderId' => $orderId]
+            )
+        );
+
+        $responseJson = $rawResponse->getBody()->getContents();
+        $responseData = $this->jsonSerializer->unserialize($responseJson);
+
+        $orderResponse = $this->getOrderFactory->create();
+        $orderResponse->setData($responseData['data']);
+
+        return $orderResponse;
+    }
+}

--- a/Model/IwocaClient.php
+++ b/Model/IwocaClient.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Iwoca\Iwocapay\Model;
+
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Exception\GuzzleException;
+use Magento\Framework\Exception\LocalizedException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * HTTP client wrapper that automatically verifies HMAC signatures on responses
+ */
+class IwocaClient
+{
+    private GuzzleClient $guzzleClient;
+    private Hmac $hmac;
+    private string $sellerAccessToken;
+    private LoggerInterface $logger;
+
+    /**
+     * @param GuzzleClient $guzzleClient
+     * @param Hmac $hmac
+     * @param string $sellerAccessToken
+     * @param LoggerInterface $logger
+     */
+    public function __construct(
+        GuzzleClient $guzzleClient,
+        Hmac $hmac,
+        string $sellerAccessToken,
+        LoggerInterface $logger
+    ) {
+        $this->guzzleClient = $guzzleClient;
+        $this->hmac = $hmac;
+        $this->sellerAccessToken = $sellerAccessToken;
+        $this->logger = $logger;
+    }
+
+    /**
+     * Perform GET request with automatic HMAC verification
+     *
+     * @param string $uri
+     * @param array $options
+     * @return ResponseInterface
+     * @throws GuzzleException
+     * @throws LocalizedException
+     */
+    public function get(string $uri, array $options = []): ResponseInterface
+    {
+        $response = $this->guzzleClient->get($uri, $options);
+        $isValid = $this->verifyHmacSignature($response, $uri);
+        if (!$isValid) {
+            throw new LocalizedException(__('HMAC signature verification failed'));
+        }
+
+        return $response;
+    }
+
+    /**
+     * Perform POST request (no HMAC verification)
+     *
+     * @param string $uri
+     * @param array $options
+     * @return ResponseInterface
+     * @throws GuzzleException
+     */
+    public function post(string $uri, array $options = []): ResponseInterface
+    {
+        return $this->guzzleClient->post($uri, $options);
+    }
+
+    /**
+     * Verify HMAC signature on response
+     *
+     * @param ResponseInterface $response
+     * @param string $uri
+     * @return bool True if HMAC is valid, false otherwise
+     */
+    private function verifyHmacSignature(ResponseInterface $response, string $uri): bool
+    {
+        // Extract HMAC header
+        $hmacHeader = null;
+        if ($response->hasHeader('X-Iwocapay-Hmac-Sha256')) {
+            $hmacHeaders = $response->getHeader('X-Iwocapay-Hmac-Sha256');
+            $hmacHeader = $hmacHeaders[0] ?? null;
+            $this->logger->info(sprintf('iwocaPay HMAC header received for %s: %s', $uri, $hmacHeader));
+        }
+
+        if (!$hmacHeader) {
+            $this->logger->error(sprintf('iwocaPay HMAC header missing for %s', $uri));
+            return false;
+        }
+
+        // Get response body
+        $responseBody = $response->getBody()->getContents();
+
+        // Reset body stream so it can be read again by caller
+        $response->getBody()->rewind();
+
+        // Verify we have access token
+        if (!$this->sellerAccessToken) {
+            $this->logger->error('Seller access token not configured');
+            return false;
+        }
+
+        // Compute expected HMAC
+        $computedHmac = $this->hmac->computeHmac($responseBody, $this->sellerAccessToken);
+
+        // Verify HMAC matches
+        $isValid = $this->hmac->verifyHmac($hmacHeader, $computedHmac);
+        if (!$isValid) {
+            $this->logger->error(
+                sprintf(
+                    'HMAC verification failed for %s. Expected: %s, Computed: %s',
+                    $uri,
+                    $hmacHeader,
+                    $computedHmac
+                )
+            );
+            return false;
+        }
+
+        $this->logger->info(sprintf('HMAC verification successful for %s', $uri));
+        return true;
+    }
+}

--- a/Model/IwocaClientFactory.php
+++ b/Model/IwocaClientFactory.php
@@ -5,6 +5,7 @@ namespace Iwoca\Iwocapay\Model;
 
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\ClientFactory as GuzzleClientFactory;
+use Psr\Log\LoggerInterface;
 
 class IwocaClientFactory
 {
@@ -20,33 +21,56 @@ class IwocaClientFactory
     private Config $config;
 
     /**
+     * @var Hmac
+     */
+    private Hmac $hmac;
+
+    /**
+     * @var LoggerInterface
+     */
+    private LoggerInterface $logger;
+
+    /**
      * @param GuzzleClientFactory $guzzleClientFactory
      * @param Config $config
+     * @param Hmac $hmac
+     * @param LoggerInterface $logger
      */
     public function __construct(
         GuzzleClientFactory $guzzleClientFactory,
-        Config $config
+        Config $config,
+        Hmac $hmac,
+        LoggerInterface $logger
     ) {
         $this->guzzleClientFactory = $guzzleClientFactory;
         $this->config = $config;
+        $this->hmac = $hmac;
+        $this->logger = $logger;
     }
 
     /**
-     * @return GuzzleClient
+     * Create IwocaClient with automatic HMAC verification
+     *
+     * @return IwocaClient
      */
-    public function create(): GuzzleClient
+    public function create(): IwocaClient
     {
-        $this->config->getApiBaseUrl();
-
         $config = [
-            'base_uri' => rtrim($this->config->getApiBaseUrl(), '/') . '/',
             'headers' => [
                 'Cache-Control' => 'nocache',
                 'Content-Type' => 'application/json',
-                'Authorization' => sprintf('Bearer %s', $this->config->getSellerAccessToken())
+                'Authorization' => sprintf('Bearer %s', $this->config->getSellerAccessToken()),
+                'iwocapay-integration-version' => '2.0.0'
             ],
         ];
 
-        return $this->guzzleClientFactory->create(['config' => $config]);
+        $guzzleClient = $this->guzzleClientFactory->create(['config' => $config]);
+
+        return new IwocaClient(
+            $guzzleClient,
+            $this->hmac,
+            $this->config->getSellerAccessToken(),
+            $this->logger
+        );
     }
 }

--- a/Model/IwocaClientFactory.php
+++ b/Model/IwocaClientFactory.php
@@ -60,7 +60,6 @@ class IwocaClientFactory
                 'Cache-Control' => 'nocache',
                 'Content-Type' => 'application/json',
                 'Authorization' => sprintf('Bearer %s', $this->config->getSellerAccessToken()),
-                'iwocapay-integration-version' => '2.0.0'
             ],
         ];
 

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -8,9 +8,10 @@
                 <title>iwocaPay</title>
                 <prod_base_url>https://www.iwoca.co.uk</prod_base_url>
                 <staging_base_url>https://stage.iwoca-dev.co.uk</staging_base_url>
-                <api_base_path>/api/lending/edge/</api_base_path>
-                <api_path_create_order><![CDATA[/ecommerce/seller/:sellerId/order]]></api_path_create_order>
-                <api_path_get_order><![CDATA[/ecommerce/order/:orderId]]></api_path_get_order>
+                <api_base_path_lending>/api/lending/edge/</api_base_path_lending>
+                <api_base_path_iwocapay>/api/iwocapay/</api_base_path_iwocapay>
+                <api_path_create_order><![CDATA[/ecommerce/seller/:sellerId/order/]]></api_path_create_order>
+                <api_path_get_order><![CDATA[/ecommerce/seller/:sellerId/order/:orderId/]]></api_path_get_order>
                 <can_use_checkout>1</can_use_checkout>
                 <source>iwocaPay_magento_extension</source>
                 <redirect_path>iwocapay/process/callback</redirect_path>


### PR DESCRIPTION
Adds HMAC validation to callback. We've implemented the new GET endpoint, which returns a signature as a header. The body is hashed and compared to the hmac received.

I've refactored the fetching so the HMAC validation happens after the GET, outside of the callback class.

As part of the refactor I've moved the GET stuff into another class too - it doesn't make sense this is only defined in the callback class right now.