### PR TITLE
Fix lost payments cron job

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -108,7 +108,7 @@ class Config
      */
     public function getSellerAccessToken(): string
     {
-        $encryptedValue = (string)$this->scopeConfig->getValue(self::XML_CONFIG_PATH_SELLER_ACCESS_TOKEN, ScopeInterface::SCOPE_WEBSITE);
+        $encryptedValue = (string)$this->scopeConfig->getValue(self::XML_CONFIG_PATH_SELLER_ACCESS_TOKEN, ScopeConfigInterface::SCOPE_TYPE_DEFAULT);
         return $encryptedValue ? $this->encryptor->decrypt($encryptedValue) : '';
     }
 
@@ -117,7 +117,7 @@ class Config
      */
     public function getSellerId(): string
     {
-        return (string)$this->scopeConfig->getValue(self::XML_CONFIG_PATH_SELLER_ID, ScopeInterface::SCOPE_WEBSITE);
+        return (string)$this->scopeConfig->getValue(self::XML_CONFIG_PATH_SELLER_ID, ScopeConfigInterface::SCOPE_TYPE_DEFAULT);
     }
 
 


### PR DESCRIPTION
  Fix: Cron jobs failing due to empty Seller ID in API calls

  Problem:
  The ReconcileLostPayments and CancelAbandonedOrders cron jobs were making API calls with
  empty Seller IDs, resulting in malformed URLs like
  /api/iwocapay/ecommerce/seller//order/{uuid}/. This prevented order reconciliation for
  edge cases (declined customers who didn't redirect back, customers who closed tabs before
  redirect).

  Changes:
  - Updated Config::getSellerId() to use SCOPE_TYPE_DEFAULT instead of SCOPE_WEBSITE
  - Updated Config::getSellerAccessToken() to use SCOPE_TYPE_DEFAULT instead of
  SCOPE_WEBSITE

  Why:
  When cron jobs run without website context, SCOPE_WEBSITE without an ID returns null.
  Using SCOPE_TYPE_DEFAULT ensures the global Seller ID is always retrieved correctly in all
   contexts (web, cron, CLI).

  Impact:
  Fixes order reconciliation for sellers, particularly those with multi-website/multi-store
  Magento setups.